### PR TITLE
added the API fetch code and output

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,29 @@
             }
 
             const apiKey = '2KRDUM6FnVKMg7Wd-1xaXY34m3tCapKTT06rPSlWIGY';
+            const apiUrl = `https://avwx.rest/api/metar/${icao}?token=${apiKey}`;
+
+            fetch(apiUrl)
+                .then((response) => {
+                    if (!response.ok) {
+                        throw new Error(`Could not fetch METAR data: ${response.statusText}`);
+                    }
+                    return response.json();
+                })
+                .then((data) => {
+                    if (data.error || !data.raw) {
+                        metarOutput.textContent = `Error: Could not fetch data for ICAO code "${icao}".`;
+                    } else {
+                        metarOutput.innerHTML = `
+                            <strong>Raw METAR:</strong> ${data.raw}<br>
+                            <strong>Flight Rules:</strong> ${data.flight_rules}<br>
+                            <strong>Time:</strong> ${data.time.dt}<br>
+                        `;
+                    }
+                })
+                .catch((error) => {
+                    metarOutput.textContent = `Error: ${error.message}`;
+                });
         });
 
 


### PR DESCRIPTION
I have added the Fetch API code to the fetchMetar button event listener. The API key has been included in the code, and the URL that both the key and the user inputted ICAO will feed into. 

The fetch(APIurl) returns a Promise. This then resolves to a response which is a raw JSON file, it checks if the response is valid, otherwise it returns an error. From there, the parsed JSON, or the data, is passed and checks if there is an error, or if the raw field is missing. Otherwise, all checks are passed and it now returns the output directly into the METAR output box.